### PR TITLE
fix: CSRF bypass on tests

### DIFF
--- a/workspace/app/helpers.php
+++ b/workspace/app/helpers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Custom helper functions for TrueTrack
+ *
+ * This file is autoloaded by Composer and provides global helper functions
+ * that can be used throughout the application.
+ */

--- a/workspace/tests/TestCase.php
+++ b/workspace/tests/TestCase.php
@@ -12,6 +12,9 @@ abstract class TestCase extends BaseTestCase
 
         // Create a fake Vite manifest for testing
         $this->createFakeViteManifest();
+
+        // Withouth verifying CSRF token in tests for web routes
+        $this->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class);
     }
 
     protected function tearDown(): void
@@ -80,7 +83,7 @@ abstract class TestCase extends BaseTestCase
         $manifestPath = public_path('build/manifest.json');
 
         if (file_exists($manifestPath)) {
-            unlink($manifestPath);
+            @unlink($manifestPath); // Suppress permission errors
         }
 
         // Remove the build directory if it's empty
@@ -89,7 +92,7 @@ abstract class TestCase extends BaseTestCase
             $iterator = new \FilesystemIterator($buildDir, \FilesystemIterator::SKIP_DOTS);
 
             if (! $iterator->valid()) {
-                rmdir($buildDir);
+                @rmdir($buildDir); // Suppress permission errors
             }
         }
     }


### PR DESCRIPTION
This pull request introduces a new global helper file for the application and makes improvements to the test setup to streamline testing and handle file system errors more gracefully. The most important changes are grouped below:

**New helper functions:**

* Added `workspace/app/helpers.php`, which will be autoloaded by Composer to provide global helper functions for use throughout the application.

**Test improvements:**

* Disabled CSRF token verification middleware in web route tests by adding `$this->withoutMiddleware(\Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class);` to the test setup, simplifying test execution.

**Error handling enhancements:**

* Updated file and directory removal in `removeFakeViteManifest()` to suppress permission errors by using the error suppression operator (`@`) with `unlink` and `rmdir`. [[1]](diffhunk://#diff-e4cb70a7a63b69f3a0742938f75a12448fcb08c55022af7b588bb34ac7f280abL83-R86) [[2]](diffhunk://#diff-e4cb70a7a63b69f3a0742938f75a12448fcb08c55022af7b588bb34ac7f280abL92-R95)