### PR TITLE
feat: bulk delete transactions

### DIFF
--- a/workspace/app/Http/Controllers/TransactionController.php
+++ b/workspace/app/Http/Controllers/TransactionController.php
@@ -23,12 +23,9 @@ class TransactionController extends Controller
 {
     use AuthorizesRequests;
 
-    private AccountingService $accountingService;
-
-    public function __construct(AccountingService $accountingService)
-    {
-        $this->accountingService = $accountingService;
-    }
+    public function __construct(
+        private readonly AccountingService $accountingService
+    ) {}
 
     /**
      * Display a listing of the resource.

--- a/workspace/app/Http/Controllers/TransactionController.php
+++ b/workspace/app/Http/Controllers/TransactionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\BulkDeleteTransactionRequest;
 use App\Http\Requests\StoreTransactionRequest;
 use App\Http\Requests\UpdateTransactionRequest;
 use App\Models\Account;
@@ -21,9 +22,12 @@ class TransactionController extends Controller
 {
     use AuthorizesRequests;
 
-    public function __construct(
-        private readonly AccountingService $accountingService
-    ) {}
+    private AccountingService $accountingService;
+
+    public function __construct(AccountingService $accountingService)
+    {
+        $this->accountingService = $accountingService;
+    }
 
     /**
      * Display a listing of the resource.
@@ -211,5 +215,31 @@ class TransactionController extends Controller
 
         return redirect()->route('transactions.index')
             ->with('success', 'Transaction deleted successfully.');
+    }
+
+    /**
+     * Remove multiple transactions from storage.
+     */
+    public function bulkDestroy(BulkDeleteTransactionRequest $request): RedirectResponse
+    {
+        $transactionIds = array_values(array_unique($request->validated('transaction_ids')));
+
+        $transactions = Transaction::query()
+            ->where('user_id', $request->user()->id)
+            ->whereIn('id', $transactionIds)
+            ->get();
+
+        if ($transactions->count() !== count($transactionIds)) {
+            abort(403);
+        }
+
+        foreach ($transactions as $transaction) {
+            $this->authorize('delete', $transaction);
+        }
+
+        $deletedCount = $this->accountingService->deleteTransactions($transactions);
+
+        return redirect()->route('transactions.index')
+            ->with('success', sprintf('%d transactions deleted successfully.', $deletedCount));
     }
 }

--- a/workspace/app/Http/Controllers/TransactionController.php
+++ b/workspace/app/Http/Controllers/TransactionController.php
@@ -240,6 +240,10 @@ class TransactionController extends Controller
         $deletedCount = $this->accountingService->deleteTransactions($transactions);
 
         return redirect()->route('transactions.index')
-            ->with('success', sprintf('%d transactions deleted successfully.', $deletedCount));
+            ->with('success', trans_choice(
+                ':count transaction deleted successfully.|:count transactions deleted successfully.',
+                $deletedCount,
+                ['count' => $deletedCount]
+            ));
     }
 }

--- a/workspace/app/Http/Controllers/TransactionController.php
+++ b/workspace/app/Http/Controllers/TransactionController.php
@@ -15,6 +15,7 @@ use App\Services\AccountingService;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -230,7 +231,9 @@ class TransactionController extends Controller
             ->get();
 
         if ($transactions->count() !== count($transactionIds)) {
-            abort(403);
+            throw ValidationException::withMessages([
+                'transaction_ids' => ['One or more selected transactions are invalid.'],
+            ]);
         }
 
         foreach ($transactions as $transaction) {

--- a/workspace/app/Http/Requests/BulkDeleteTransactionRequest.php
+++ b/workspace/app/Http/Requests/BulkDeleteTransactionRequest.php
@@ -28,7 +28,9 @@ class BulkDeleteTransactionRequest extends FormRequest
             'transaction_ids' => ['required', 'array', 'min:1'],
             'transaction_ids.*' => [
                 'integer',
-                Rule::exists('transactions', 'id')->where('user_id', $this->user()->id),
+                Rule::exists('transactions', 'id')
+                    ->where('user_id', $this->user()->id)
+                    ->whereNull('deleted_at'),
             ],
         ];
     }

--- a/workspace/app/Http/Requests/BulkDeleteTransactionRequest.php
+++ b/workspace/app/Http/Requests/BulkDeleteTransactionRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class BulkDeleteTransactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'transaction_ids' => ['required', 'array', 'min:1'],
+            'transaction_ids.*' => [
+                'integer',
+                Rule::exists('transactions', 'id')->where('user_id', $this->user()->id),
+            ],
+        ];
+    }
+}

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -151,7 +151,9 @@ class AccountingService
                 ->sort()
                 ->values();
 
+            // Fetch all accounts including soft-deleted (transactions may reference trashed accounts)
             $accounts = Account::query()
+                ->withTrashed()
                 ->whereIn('id', $accountIds)
                 ->orderBy('id')
                 ->lockForUpdate()
@@ -183,7 +185,7 @@ class AccountingService
                 $account = $accounts->get($accountId);
 
                 if (! $account instanceof Account) {
-                    continue;
+                    throw new RuntimeException(sprintf('Account %d not found or not locked properly.', $accountId));
                 }
 
                 /** @var Carbon $firstAffectedMonth */

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -12,6 +12,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
+use RuntimeException;
 
 class AccountingService
 {
@@ -125,9 +126,7 @@ class AccountingService
      */
     public function deleteTransaction(Transaction $transaction): bool
     {
-        $this->deleteTransactions([$transaction]);
-
-        return true;
+        return $this->deleteTransactions([$transaction]) === 1;
     }
 
     /**
@@ -160,9 +159,16 @@ class AccountingService
                 ->keyBy('id');
 
             $affectedPeriods = [];
+            $deletedCount = 0;
 
             foreach ($transactions as $transaction) {
-                $transaction->delete();
+                $deleted = $transaction->delete();
+
+                if ($deleted === false) {
+                    throw new RuntimeException(sprintf('Failed to delete transaction %d.', $transaction->id));
+                }
+
+                $deletedCount++;
 
                 $transactionDate = Carbon::parse((string) $transaction->transaction_date);
 
@@ -187,7 +193,7 @@ class AccountingService
 
             DB::commit();
 
-            return $transactions->count();
+            return $deletedCount;
         } catch (\Exception $e) {
             DB::rollBack();
             throw $e;

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -9,6 +9,7 @@ use App\Models\Account;
 use App\Models\AccountBalance;
 use App\Models\Transaction;
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 
@@ -124,26 +125,67 @@ class AccountingService
      */
     public function deleteTransaction(Transaction $transaction): bool
     {
+        $this->deleteTransactions([$transaction]);
+
+        return true;
+    }
+
+    /**
+     * Delete multiple transactions and recalculate affected balances.
+     *
+     * @param  iterable<Transaction>  $transactions
+     */
+    public function deleteTransactions(iterable $transactions): int
+    {
+        $transactions = Collection::make($transactions)->values();
+
+        if ($transactions->isEmpty()) {
+            return 0;
+        }
+
         DB::beginTransaction();
 
         try {
-            // Lock account
-            $account = Account::query()
-                ->where('id', $transaction->account_id)
+            $accountIds = $transactions
+                ->pluck('account_id')
+                ->unique()
+                ->sort()
+                ->values();
+
+            $accounts = Account::query()
+                ->whereIn('id', $accountIds)
+                ->orderBy('id')
                 ->lockForUpdate()
-                ->firstOrFail();
+                ->get()
+                ->keyBy('id');
 
-            $transactionDate = Carbon::parse($transaction->transaction_date);
+            $affectedPeriods = [];
 
-            // Delete transaction (soft delete)
-            $transaction->delete();
+            foreach ($transactions as $transaction) {
+                $transaction->delete();
 
-            // Recalculate balance for this month
-            $this->recalculateMonthlyBalance($account, $transactionDate);
+                $affectedPeriods[$transaction->account_id][$transaction->transaction_date->format('Y-m')] = Carbon::create(
+                    $transaction->transaction_date->year,
+                    $transaction->transaction_date->month,
+                    1
+                );
+            }
+
+            foreach ($affectedPeriods as $accountId => $periods) {
+                $account = $accounts->get($accountId);
+
+                if (! $account instanceof Account) {
+                    continue;
+                }
+
+                foreach ($periods as $date) {
+                    $this->recalculateMonthlyBalance($account, $date);
+                }
+            }
 
             DB::commit();
 
-            return true;
+            return $transactions->count();
         } catch (\Exception $e) {
             DB::rollBack();
             throw $e;

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -136,7 +136,15 @@ class AccountingService
      */
     public function deleteTransactions(iterable $transactions): int
     {
-        $transactions = Collection::make($transactions)->values();
+        $transactions = Collection::make($transactions)
+            ->unique(static function (Transaction $transaction): string {
+                $transactionKey = $transaction->getKey();
+
+                return $transactionKey !== null
+                    ? 'id:'.$transactionKey
+                    : 'object:'.spl_object_hash($transaction);
+            })
+            ->values();
 
         if ($transactions->isEmpty()) {
             return 0;

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -200,16 +200,36 @@ class AccountingService
                     ->orderByDesc('month')
                     ->first();
 
-                $lastMonthToRecalculate = Carbon::now()->startOfMonth();
+                // Limit recalculation to necessary months:
+                // Use the latest existing snapshot month as baseline,
+                // but extend through the latest remaining transaction month
+                // to avoid creating unnecessary snapshots for months with no activity.
+                $lastMonthToRecalculate = null;
 
                 if ($latestSnapshot !== null) {
-                    $latestSnapshotMonth = Carbon::create($latestSnapshot->year, $latestSnapshot->month, 1)->startOfMonth();
+                    $lastMonthToRecalculate = Carbon::create($latestSnapshot->year, $latestSnapshot->month, 1)->startOfMonth();
+                }
 
-                    if ($latestSnapshotMonth->greaterThan($lastMonthToRecalculate)) {
-                        $lastMonthToRecalculate = $latestSnapshotMonth;
+                $latestTransactionMonth = Transaction::query()
+                    ->where('account_id', $account->id)
+                    ->whereNull('deleted_at')
+                    ->orderByDesc('transaction_date')
+                    ->value('transaction_date');
+
+                if ($latestTransactionMonth !== null) {
+                    $latestTransactionMonthStart = Carbon::parse((string) $latestTransactionMonth)->startOfMonth();
+
+                    if ($lastMonthToRecalculate === null || $latestTransactionMonthStart->greaterThan($lastMonthToRecalculate)) {
+                        $lastMonthToRecalculate = $latestTransactionMonthStart;
                     }
                 }
 
+                // Even if no existing snapshots or remaining transactions,
+                // always recalculate at least the affected month to ensure
+                // its balance snapshot reflects the deletion(s).
+                if ($lastMonthToRecalculate === null || $firstAffectedMonth->greaterThan($lastMonthToRecalculate)) {
+                    $lastMonthToRecalculate = $firstAffectedMonth;
+                }
                 $monthCursor = $firstAffectedMonth->copy();
 
                 while ($monthCursor->lessThanOrEqualTo($lastMonthToRecalculate)) {

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -186,8 +186,33 @@ class AccountingService
                     continue;
                 }
 
-                foreach ($periods as $date) {
-                    $this->recalculateMonthlyBalance($account, $date);
+                /** @var Carbon $firstAffectedMonth */
+                $firstAffectedMonth = Collection::make($periods)
+                    ->sortBy(fn (Carbon $date): int => $date->year * 100 + $date->month)
+                    ->first()
+                    ->startOfMonth();
+
+                $latestSnapshot = AccountBalance::query()
+                    ->where('account_id', $account->id)
+                    ->orderByDesc('year')
+                    ->orderByDesc('month')
+                    ->first();
+
+                $lastMonthToRecalculate = Carbon::now()->startOfMonth();
+
+                if ($latestSnapshot !== null) {
+                    $latestSnapshotMonth = Carbon::create($latestSnapshot->year, $latestSnapshot->month, 1)->startOfMonth();
+
+                    if ($latestSnapshotMonth->greaterThan($lastMonthToRecalculate)) {
+                        $lastMonthToRecalculate = $latestSnapshotMonth;
+                    }
+                }
+
+                $monthCursor = $firstAffectedMonth->copy();
+
+                while ($monthCursor->lessThanOrEqualTo($lastMonthToRecalculate)) {
+                    $this->recalculateMonthlyBalance($account, $monthCursor);
+                    $monthCursor->addMonth();
                 }
             }
 

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -164,9 +164,11 @@ class AccountingService
             foreach ($transactions as $transaction) {
                 $transaction->delete();
 
-                $affectedPeriods[$transaction->account_id][$transaction->transaction_date->format('Y-m')] = Carbon::create(
-                    $transaction->transaction_date->year,
-                    $transaction->transaction_date->month,
+                $transactionDate = Carbon::parse((string) $transaction->transaction_date);
+
+                $affectedPeriods[$transaction->account_id][$transactionDate->format('Y-m')] = Carbon::create(
+                    $transactionDate->year,
+                    $transactionDate->month,
                     1
                 );
             }

--- a/workspace/app/Services/AccountingService.php
+++ b/workspace/app/Services/AccountingService.php
@@ -238,12 +238,48 @@ class AccountingService
                 if ($lastMonthToRecalculate === null || $firstAffectedMonth->greaterThan($lastMonthToRecalculate)) {
                     $lastMonthToRecalculate = $firstAffectedMonth;
                 }
-                $monthCursor = $firstAffectedMonth->copy();
+                $monthsToRecalculate = Collection::make($periods)
+                    ->map(fn (Carbon $date): Carbon => $date->copy()->startOfMonth())
+                    ->keyBy(fn (Carbon $date): string => $date->format('Y-m'));
 
-                while ($monthCursor->lessThanOrEqualTo($lastMonthToRecalculate)) {
-                    $this->recalculateMonthlyBalance($account, $monthCursor);
-                    $monthCursor->addMonth();
+                $existingSnapshotMonths = AccountBalance::query()
+                    ->where('account_id', $account->id)
+                    ->where(function ($query) use ($firstAffectedMonth): void {
+                        $query
+                            ->where('year', '>', $firstAffectedMonth->year)
+                            ->orWhere(function ($nestedQuery) use ($firstAffectedMonth): void {
+                                $nestedQuery
+                                    ->where('year', $firstAffectedMonth->year)
+                                    ->where('month', '>=', $firstAffectedMonth->month);
+                            });
+                    })
+                    ->where(function ($query) use ($lastMonthToRecalculate): void {
+                        $query
+                            ->where('year', '<', $lastMonthToRecalculate->year)
+                            ->orWhere(function ($nestedQuery) use ($lastMonthToRecalculate): void {
+                                $nestedQuery
+                                    ->where('year', $lastMonthToRecalculate->year)
+                                    ->where('month', '<=', $lastMonthToRecalculate->month);
+                            });
+                    })
+                    ->orderBy('year')
+                    ->orderBy('month')
+                    ->get(['year', 'month'])
+                    ->map(function (AccountBalance $snapshot): Carbon {
+                        return Carbon::create($snapshot->year, $snapshot->month, 1)->startOfMonth();
+                    });
+
+                foreach ($existingSnapshotMonths as $snapshotMonth) {
+                    $monthsToRecalculate->put($snapshotMonth->format('Y-m'), $snapshotMonth);
                 }
+
+                $monthsToRecalculate->put($lastMonthToRecalculate->format('Y-m'), $lastMonthToRecalculate->copy()->startOfMonth());
+
+                $monthsToRecalculate
+                    ->sortBy(fn (Carbon $date): int => $date->year * 100 + $date->month)
+                    ->each(function (Carbon $month) use ($account): void {
+                        $this->recalculateMonthlyBalance($account, $month);
+                    });
             }
 
             DB::commit();

--- a/workspace/jest.setup.js
+++ b/workspace/jest.setup.js
@@ -10,6 +10,14 @@ global.route = (name, params) => {
         'accounts.edit': (id) => `/accounts/${id}/edit`,
         'accounts.update': (id) => `/accounts/${id}`,
         'accounts.destroy': (id) => `/accounts/${id}`,
+        'transactions.index': '/transactions',
+        'transactions.create': '/transactions/create',
+        'transactions.store': '/transactions',
+        'transactions.show': (id) => `/transactions/${id}`,
+        'transactions.edit': (id) => `/transactions/${id}/edit`,
+        'transactions.update': (id) => `/transactions/${id}`,
+        'transactions.destroy': (id) => `/transactions/${id}`,
+        'transactions.bulk-destroy': '/transactions/bulk-delete',
     };
 
     if (typeof routes[name] === 'function') {

--- a/workspace/resources/js/Pages/Categories/Create.jsx
+++ b/workspace/resources/js/Pages/Categories/Create.jsx
@@ -39,7 +39,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
         <AuthenticatedLayout
             user={auth.user}
             header={
-                <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                <h2 className="font-semibold text-xl text-gray-800 leading-tight dark:text-gray-100">
                     Create Category
                 </h2>
             }
@@ -48,7 +48,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
 
             <div className="py-12">
                 <div className="max-w-2xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg dark:bg-gray-800">
                         <div className="p-6">
                             <form onSubmit={handleSubmit}>
                                 {/* Category Name */}
@@ -73,7 +73,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                         id="type"
                                         value={data.type}
                                         onChange={(e) => setData('type', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                         required
                                     >
                                         {categoryTypes.map((type) => (
@@ -83,7 +83,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                         ))}
                                     </select>
                                     <InputError message={errors.type} className="mt-2" />
-                                    <p className="mt-1 text-sm text-gray-600">
+                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                                         Revenue categories for income, Expense categories for spending.
                                     </p>
                                 </div>
@@ -95,7 +95,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                         id="parent_id"
                                         value={data.parent_id}
                                         onChange={(e) => setData('parent_id', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                     >
                                         <option value="">None - This is a parent category</option>
                                         {filteredParentCategories.map((parent) => (
@@ -105,7 +105,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                         ))}
                                     </select>
                                     <InputError message={errors.parent_id} className="mt-2" />
-                                    <p className="mt-1 text-sm text-gray-600">
+                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                                         Create subcategories by selecting a parent. Must be the same type.
                                     </p>
                                 </div>
@@ -117,7 +117,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                         id="description"
                                         value={data.description}
                                         onChange={(e) => setData('description', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                         rows="3"
                                     />
                                     <InputError message={errors.description} className="mt-2" />
@@ -130,9 +130,9 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                             type="checkbox"
                                             checked={data.is_active}
                                             onChange={(e) => setData('is_active', e.target.checked)}
-                                            className="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                            className="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900"
                                         />
-                                        <span className="ml-2 text-sm text-gray-600">
+                                        <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">
                                             Category is active
                                         </span>
                                     </label>
@@ -143,7 +143,7 @@ export default function Create({ auth, categoryTypes, parentCategories }) {
                                 <div className="flex items-center justify-end gap-4">
                                     <Link
                                         href={route('categories.index')}
-                                        className="text-sm text-gray-600 hover:text-gray-900"
+                                        className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                                     >
                                         Cancel
                                     </Link>

--- a/workspace/resources/js/Pages/Categories/Edit.jsx
+++ b/workspace/resources/js/Pages/Categories/Edit.jsx
@@ -39,7 +39,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
         <AuthenticatedLayout
             user={auth.user}
             header={
-                <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                <h2 className="font-semibold text-xl text-gray-800 leading-tight dark:text-gray-100">
                     Edit Category: {category.name}
                 </h2>
             }
@@ -48,7 +48,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
 
             <div className="py-12">
                 <div className="max-w-2xl mx-auto sm:px-6 lg:px-8">
-                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg dark:bg-gray-800">
                         <div className="p-6">
                             <form onSubmit={handleSubmit}>
                                 {/* Category Name */}
@@ -73,7 +73,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                         id="type"
                                         value={data.type}
                                         onChange={(e) => setData('type', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                         required
                                     >
                                         {categoryTypes.map((type) => (
@@ -83,7 +83,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                         ))}
                                     </select>
                                     <InputError message={errors.type} className="mt-2" />
-                                    <p className="mt-1 text-sm text-gray-600">
+                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                                         Revenue categories for income, Expense categories for spending.
                                     </p>
                                 </div>
@@ -95,7 +95,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                         id="parent_id"
                                         value={data.parent_id}
                                         onChange={(e) => setData('parent_id', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                     >
                                         <option value="">None - This is a parent category</option>
                                         {filteredParentCategories.map((parent) => (
@@ -105,7 +105,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                         ))}
                                     </select>
                                     <InputError message={errors.parent_id} className="mt-2" />
-                                    <p className="mt-1 text-sm text-gray-600">
+                                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
                                         Create subcategories by selecting a parent. Must be the same type.
                                     </p>
                                 </div>
@@ -117,7 +117,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                         id="description"
                                         value={data.description}
                                         onChange={(e) => setData('description', e.target.value)}
-                                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                        className="mt-1 block w-full border-gray-300 rounded-md bg-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                                         rows="3"
                                     />
                                     <InputError message={errors.description} className="mt-2" />
@@ -130,9 +130,9 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                             type="checkbox"
                                             checked={data.is_active}
                                             onChange={(e) => setData('is_active', e.target.checked)}
-                                            className="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500"
+                                            className="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-900"
                                         />
-                                        <span className="ml-2 text-sm text-gray-600">
+                                        <span className="ml-2 text-sm text-gray-600 dark:text-gray-300">
                                             Category is active
                                         </span>
                                     </label>
@@ -141,8 +141,8 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
 
                                 {/* Warning if has children */}
                                 {category.has_children && (
-                                    <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
-                                        <p className="text-sm text-yellow-800">
+                                    <div className="mb-6 p-4 bg-yellow-50 border border-yellow-200 rounded-md dark:bg-yellow-500/10 dark:border-yellow-500/40">
+                                        <p className="text-sm text-yellow-800 dark:text-yellow-300">
                                             <strong>Note:</strong> This category has subcategories. Changing the type will affect all subcategories.
                                         </p>
                                     </div>
@@ -152,7 +152,7 @@ export default function Edit({ auth, category, categoryTypes, parentCategories }
                                 <div className="flex items-center justify-end gap-4">
                                     <Link
                                         href={route('categories.index')}
-                                        className="text-sm text-gray-600 hover:text-gray-900"
+                                        className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                                     >
                                         Cancel
                                     </Link>

--- a/workspace/resources/js/Pages/Transactions/Index.jsx
+++ b/workspace/resources/js/Pages/Transactions/Index.jsx
@@ -98,16 +98,13 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
         const transactionLabel = transactionCount === 1 ? 'transaction' : 'transactions';
 
         if (confirm(`Are you sure you want to delete ${transactionCount} selected ${transactionLabel}? This will adjust the account balances.`)) {
-            router.delete(
-                route('transactions.bulk-destroy'),
-                {
+            router.delete(route('transactions.bulk-destroy'), {
+                data: {
                     transaction_ids: selectedTransactionIds,
                 },
-                {
-                    preserveScroll: true,
-                    onSuccess: () => setSelectedTransactionIds([]),
-                }
-            );
+                preserveScroll: true,
+                onSuccess: () => setSelectedTransactionIds([]),
+            });
         }
     };
 

--- a/workspace/resources/js/Pages/Transactions/Index.jsx
+++ b/workspace/resources/js/Pages/Transactions/Index.jsx
@@ -15,9 +15,10 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
     const selectAllRef = useRef(null);
 
     const visibleTransactionIds = transactions?.data?.map((transaction) => transaction.id) || [];
+    const selectedTransactionIdSet = new Set(selectedTransactionIds);
     const allVisibleSelected = visibleTransactionIds.length > 0
-        && visibleTransactionIds.every((transactionId) => selectedTransactionIds.includes(transactionId));
-    const someVisibleSelected = visibleTransactionIds.some((transactionId) => selectedTransactionIds.includes(transactionId));
+        && visibleTransactionIds.every((transactionId) => selectedTransactionIdSet.has(transactionId));
+    const someVisibleSelected = visibleTransactionIds.some((transactionId) => selectedTransactionIdSet.has(transactionId));
 
     useEffect(() => {
         if (selectAllRef.current) {
@@ -402,7 +403,7 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
                                             </thead>
                                             <tbody className="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700">
                                                 {transactions?.data?.map((transaction) => {
-                                                    const isSelected = selectedTransactionIds.includes(transaction.id);
+                                                    const isSelected = selectedTransactionIdSet.has(transaction.id);
 
                                                     return (
                                                         <tr key={transaction.id} className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 ${isSelected ? 'bg-indigo-50/60 dark:bg-indigo-900/20' : ''}`}>

--- a/workspace/resources/js/Pages/Transactions/Index.jsx
+++ b/workspace/resources/js/Pages/Transactions/Index.jsx
@@ -80,7 +80,13 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
 
     const toggleAllVisibleTransactions = () => {
         setSelectedTransactionIds((currentSelection) => {
-            if (allVisibleSelected) {
+            const currentSelectionSet = new Set(currentSelection);
+            const allCurrentlyVisibleSelected = visibleTransactionIds.length > 0
+                && visibleTransactionIds.every(
+                    (transactionId) => currentSelectionSet.has(transactionId)
+                );
+
+            if (allCurrentlyVisibleSelected) {
                 return currentSelection.filter(
                     (transactionId) => !visibleTransactionIds.includes(transactionId)
                 );

--- a/workspace/resources/js/Pages/Transactions/Index.jsx
+++ b/workspace/resources/js/Pages/Transactions/Index.jsx
@@ -371,7 +371,7 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
                                                             type="checkbox"
                                                             checked={allVisibleSelected}
                                                             onChange={toggleAllVisibleTransactions}
-                                                            aria-label="Select all transactions"
+                                                            aria-label="Select all visible transactions"
                                                             className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600"
                                                         />
                                                     </th>

--- a/workspace/resources/js/Pages/Transactions/Index.jsx
+++ b/workspace/resources/js/Pages/Transactions/Index.jsx
@@ -1,6 +1,6 @@
 import { Head, Link, router } from '@inertiajs/react';
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import normalizeInertiaUrl from '@/Utils/normalizeInertiaUrl';
 
 export default function Index({ auth, transactions, accounts, categories, tags, filters }) {
@@ -11,6 +11,23 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
     const [filterDateFrom, setFilterDateFrom] = useState(filters?.filter?.date_from || '');
     const [filterDateTo, setFilterDateTo] = useState(filters?.filter?.date_to || '');
     const [filterTag, setFilterTag] = useState(filters?.filter?.tag || '');
+    const [selectedTransactionIds, setSelectedTransactionIds] = useState([]);
+    const selectAllRef = useRef(null);
+
+    const visibleTransactionIds = transactions?.data?.map((transaction) => transaction.id) || [];
+    const allVisibleSelected = visibleTransactionIds.length > 0
+        && visibleTransactionIds.every((transactionId) => selectedTransactionIds.includes(transactionId));
+    const someVisibleSelected = visibleTransactionIds.some((transactionId) => selectedTransactionIds.includes(transactionId));
+
+    useEffect(() => {
+        if (selectAllRef.current) {
+            selectAllRef.current.indeterminate = someVisibleSelected && !allVisibleSelected;
+        }
+    }, [allVisibleSelected, someVisibleSelected]);
+
+    useEffect(() => {
+        setSelectedTransactionIds([]);
+    }, [transactions?.data]);
 
     const transactionTypes = [
         { value: '', label: 'All Types' },
@@ -52,9 +69,45 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
         router.get(route('transactions.index'));
     };
 
-    const deleteTransaction = (transactionId) => {
-        if (confirm('Are you sure you want to delete this transaction? This will adjust the account balance.')) {
-            router.delete(route('transactions.destroy', transactionId));
+    const toggleTransactionSelection = (transactionId) => {
+        setSelectedTransactionIds((currentSelection) => (
+            currentSelection.includes(transactionId)
+                ? currentSelection.filter((selectedTransactionId) => selectedTransactionId !== transactionId)
+                : [...currentSelection, transactionId]
+        ));
+    };
+
+    const toggleAllVisibleTransactions = () => {
+        setSelectedTransactionIds((currentSelection) => {
+            if (allVisibleSelected) {
+                return currentSelection.filter(
+                    (transactionId) => !visibleTransactionIds.includes(transactionId)
+                );
+            }
+
+            return Array.from(new Set([...currentSelection, ...visibleTransactionIds]));
+        });
+    };
+
+    const deleteSelectedTransactions = () => {
+        if (selectedTransactionIds.length === 0) {
+            return;
+        }
+
+        const transactionCount = selectedTransactionIds.length;
+        const transactionLabel = transactionCount === 1 ? 'transaction' : 'transactions';
+
+        if (confirm(`Are you sure you want to delete ${transactionCount} selected ${transactionLabel}? This will adjust the account balances.`)) {
+            router.delete(
+                route('transactions.bulk-destroy'),
+                {
+                    transaction_ids: selectedTransactionIds,
+                },
+                {
+                    preserveScroll: true,
+                    onSuccess: () => setSelectedTransactionIds([]),
+                }
+            );
         }
     };
 
@@ -288,78 +341,118 @@ export default function Index({ auth, transactions, accounts, categories, tags, 
                                     </Link>
                                 </div>
                             ) : (
-                                <div className="overflow-x-auto">
-                                    <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                                        <thead className="bg-gray-50 dark:bg-gray-900/40">
-                                            <tr>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Date
-                                                </th>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Account
-                                                </th>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Category
-                                                </th>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Description
-                                                </th>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Type
-                                                </th>
-                                                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Amount
-                                                </th>
-                                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Status
-                                                </th>
-                                                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
-                                                    Actions
-                                                </th>
-                                            </tr>
-                                        </thead>
-                                        <tbody className="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700">
-                                            {transactions?.data?.map((transaction) => (
-                                                <tr key={transaction.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
-                                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                                                        {formatDate(transaction.transaction_date)}
-                                                    </td>
-                                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                                                        {transaction.account?.name || 'N/A'}
-                                                    </td>
-                                                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
-                                                        {transaction.category?.name || 'N/A'}
-                                                    </td>
-                                                    <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
-                                                        {transaction.description || '—'}
-                                                    </td>
-                                                    <td className="px-6 py-4 whitespace-nowrap">
-                                                        {getTypeBadge(transaction.type)}
-                                                    </td>
-                                                    <td className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${getTypeClass(transaction.type)}`}>
-                                                        {formatCurrency(transaction.amount)}
-                                                    </td>
-                                                    <td className="px-6 py-4 whitespace-nowrap">
-                                                        {getSettledBadge(transaction.settled_date)}
-                                                    </td>
-                                                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                                        <Link
-                                                            href={route('transactions.edit', transaction.id)}
-                                                            className="mr-3 text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
-                                                        >
-                                                            Edit
-                                                        </Link>
-                                                        <button
-                                                            onClick={() => deleteTransaction(transaction.id)}
-                                                            className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300"
-                                                        >
-                                                            Delete
-                                                        </button>
-                                                    </td>
+                                <div>
+                                    <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                        <div>
+                                            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                                                Transaction List
+                                            </h3>
+                                            <p className="text-sm text-gray-500 dark:text-gray-400">
+                                                {selectedTransactionIds.length > 0
+                                                    ? `${selectedTransactionIds.length} selected`
+                                                    : 'Select rows to delete them in bulk.'}
+                                            </p>
+                                        </div>
+                                        <button
+                                            type="button"
+                                            onClick={deleteSelectedTransactions}
+                                            disabled={selectedTransactionIds.length === 0}
+                                            className="inline-flex items-center justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300 dark:bg-red-500 dark:hover:bg-red-400 dark:disabled:bg-red-900/50"
+                                        >
+                                            Delete Selected ({selectedTransactionIds.length})
+                                        </button>
+                                    </div>
+
+                                    <div className="overflow-x-auto">
+                                        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                            <thead className="bg-gray-50 dark:bg-gray-900/40">
+                                                <tr>
+                                                    <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                                                        <input
+                                                            ref={selectAllRef}
+                                                            type="checkbox"
+                                                            checked={allVisibleSelected}
+                                                            onChange={toggleAllVisibleTransactions}
+                                                            aria-label="Select all transactions"
+                                                            className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600"
+                                                        />
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Date
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Account
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Category
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Description
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Type
+                                                    </th>
+                                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Amount
+                                                    </th>
+                                                    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Status
+                                                    </th>
+                                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider dark:text-gray-400">
+                                                        Actions
+                                                    </th>
                                                 </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
+                                            </thead>
+                                            <tbody className="bg-white divide-y divide-gray-200 dark:bg-gray-800 dark:divide-gray-700">
+                                                {transactions?.data?.map((transaction) => {
+                                                    const isSelected = selectedTransactionIds.includes(transaction.id);
+
+                                                    return (
+                                                        <tr key={transaction.id} className={`hover:bg-gray-50 dark:hover:bg-gray-700/40 ${isSelected ? 'bg-indigo-50/60 dark:bg-indigo-900/20' : ''}`}>
+                                                            <td className="px-4 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                                                <input
+                                                                    type="checkbox"
+                                                                    checked={isSelected}
+                                                                    onChange={() => toggleTransactionSelection(transaction.id)}
+                                                                    aria-label={`Select transaction ${transaction.id}`}
+                                                                    className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600"
+                                                                />
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                                                {formatDate(transaction.transaction_date)}
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                                                {transaction.account?.name || 'N/A'}
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                                                {transaction.category?.name || 'N/A'}
+                                                            </td>
+                                                            <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                                                {transaction.description || '—'}
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap">
+                                                                {getTypeBadge(transaction.type)}
+                                                            </td>
+                                                            <td className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${getTypeClass(transaction.type)}`}>
+                                                                {formatCurrency(transaction.amount)}
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap">
+                                                                {getSettledBadge(transaction.settled_date)}
+                                                            </td>
+                                                            <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                                                <Link
+                                                                    href={route('transactions.edit', transaction.id)}
+                                                                    className="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300"
+                                                                >
+                                                                    Edit
+                                                                </Link>
+                                                            </td>
+                                                        </tr>
+                                                    );
+                                                })}
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
                             )}
 

--- a/workspace/resources/js/__tests__/Transactions/Index.test.jsx
+++ b/workspace/resources/js/__tests__/Transactions/Index.test.jsx
@@ -86,7 +86,7 @@ describe('Transactions Index', () => {
 
         expect(screen.getByText('Transaction List')).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Delete Selected \(0\)/i })).toBeDisabled();
-        expect(screen.getByLabelText('Select all transactions')).toBeInTheDocument();
+        expect(screen.getByLabelText('Select all visible transactions')).toBeInTheDocument();
     });
 
     test('enables bulk delete after selecting a row', () => {
@@ -118,7 +118,7 @@ describe('Transactions Index', () => {
             />
         );
 
-        fireEvent.click(screen.getByLabelText('Select all transactions'));
+        fireEvent.click(screen.getByLabelText('Select all visible transactions'));
 
         expect(screen.getByLabelText('Select transaction 1')).toBeChecked();
         expect(screen.getByLabelText('Select transaction 2')).toBeChecked();

--- a/workspace/resources/js/__tests__/Transactions/Index.test.jsx
+++ b/workspace/resources/js/__tests__/Transactions/Index.test.jsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import Index from '@/Pages/Transactions/Index';
+
+jest.mock('@inertiajs/react', () => ({
+    ...jest.requireActual('@inertiajs/react'),
+    router: {
+        get: jest.fn(),
+        delete: jest.fn(),
+    },
+    Head: ({ children }) => <>{children}</>,
+    Link: ({ children, href }) => <a href={href}>{children}</a>,
+}));
+
+jest.mock('@/Layouts/AuthenticatedLayout', () => ({
+    __esModule: true,
+    default: ({ children, header }) => (
+        <div data-testid="authenticated-layout">
+            <div data-testid="header">{header}</div>
+            {children}
+        </div>
+    ),
+}));
+
+describe('Transactions Index', () => {
+    const mockAuth = {
+        user: {
+            id: 1,
+            name: 'Test User',
+            email: 'test@example.com',
+        },
+    };
+
+    const mockTransactions = {
+        data: [
+            {
+                id: 1,
+                account_id: 1,
+                category_id: 1,
+                amount: '120.50',
+                description: 'Groceries',
+                transaction_date: '2026-01-10',
+                settled_date: '2026-01-11',
+                type: 'debit',
+                account: { name: 'Checking' },
+                category: { name: 'Food' },
+            },
+            {
+                id: 2,
+                account_id: 1,
+                category_id: 2,
+                amount: '250.00',
+                description: 'Salary',
+                transaction_date: '2026-01-15',
+                settled_date: null,
+                type: 'credit',
+                account: { name: 'Checking' },
+                category: { name: 'Income' },
+            },
+        ],
+        links: [],
+        meta: {
+            current_page: 1,
+            from: 1,
+            to: 2,
+            total: 2,
+            per_page: 15,
+        },
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.confirm = jest.fn(() => true);
+    });
+
+    test('renders bulk delete controls', () => {
+        render(
+            <Index
+                auth={mockAuth}
+                transactions={mockTransactions}
+                accounts={{ data: [] }}
+                categories={{ data: [] }}
+                tags={{ data: [] }}
+                filters={{}}
+            />
+        );
+
+        expect(screen.getByText('Transaction List')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Delete Selected \(0\)/i })).toBeDisabled();
+        expect(screen.getByLabelText('Select all transactions')).toBeInTheDocument();
+    });
+
+    test('enables bulk delete after selecting a row', () => {
+        render(
+            <Index
+                auth={mockAuth}
+                transactions={mockTransactions}
+                accounts={{ data: [] }}
+                categories={{ data: [] }}
+                tags={{ data: [] }}
+                filters={{}}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Select transaction 1'));
+
+        expect(screen.getByRole('button', { name: /Delete Selected \(1\)/i })).toBeEnabled();
+    });
+
+    test('select all toggles every visible row', () => {
+        render(
+            <Index
+                auth={mockAuth}
+                transactions={mockTransactions}
+                accounts={{ data: [] }}
+                categories={{ data: [] }}
+                tags={{ data: [] }}
+                filters={{}}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Select all transactions'));
+
+        expect(screen.getByLabelText('Select transaction 1')).toBeChecked();
+        expect(screen.getByLabelText('Select transaction 2')).toBeChecked();
+        expect(screen.getByRole('button', { name: /Delete Selected \(2\)/i })).toBeEnabled();
+    });
+
+    test('bulk delete sends selected transaction ids', () => {
+        const { router } = jest.requireMock('@inertiajs/react');
+
+        render(
+            <Index
+                auth={mockAuth}
+                transactions={mockTransactions}
+                accounts={{ data: [] }}
+                categories={{ data: [] }}
+                tags={{ data: [] }}
+                filters={{}}
+            />
+        );
+
+        fireEvent.click(screen.getByLabelText('Select transaction 1'));
+        fireEvent.click(screen.getByRole('button', { name: /Delete Selected \(1\)/i }));
+
+        expect(global.confirm).toHaveBeenCalledWith(
+            'Are you sure you want to delete 1 selected transaction? This will adjust the account balances.'
+        );
+        expect(router.delete).toHaveBeenCalledWith(
+            '/transactions/bulk-delete',
+            { transaction_ids: [1] },
+            expect.objectContaining({ preserveScroll: true, onSuccess: expect.any(Function) })
+        );
+    });
+
+    test('does not render row delete buttons anymore', () => {
+        render(
+            <Index
+                auth={mockAuth}
+                transactions={mockTransactions}
+                accounts={{ data: [] }}
+                categories={{ data: [] }}
+                tags={{ data: [] }}
+                filters={{}}
+            />
+        );
+
+        expect(screen.getAllByText('Edit')).toHaveLength(2);
+        expect(screen.queryByText('Delete')).not.toBeInTheDocument();
+    });
+});

--- a/workspace/resources/js/__tests__/Transactions/Index.test.jsx
+++ b/workspace/resources/js/__tests__/Transactions/Index.test.jsx
@@ -147,8 +147,11 @@ describe('Transactions Index', () => {
         );
         expect(router.delete).toHaveBeenCalledWith(
             '/transactions/bulk-delete',
-            { transaction_ids: [1] },
-            expect.objectContaining({ preserveScroll: true, onSuccess: expect.any(Function) })
+            expect.objectContaining({
+                data: { transaction_ids: [1] },
+                preserveScroll: true,
+                onSuccess: expect.any(Function),
+            })
         );
     });
 

--- a/workspace/routes/web.php
+++ b/workspace/routes/web.php
@@ -24,6 +24,8 @@ Route::middleware('auth')->group(function () {
     Route::resource('tags', App\Http\Controllers\TagController::class);
 
     // Transaction management
+    Route::delete('/transactions/bulk-delete', [App\Http\Controllers\TransactionController::class, 'bulkDestroy'])
+        ->name('transactions.bulk-destroy');
     Route::resource('transactions', App\Http\Controllers\TransactionController::class);
 
     // Reconciliation management

--- a/workspace/tests/Feature/TransactionControllerTest.php
+++ b/workspace/tests/Feature/TransactionControllerTest.php
@@ -338,4 +338,22 @@ class TransactionControllerTest extends TestCase
 
         $response->assertSessionHasErrors(['transaction_ids.0']);
     }
+
+    public function test_user_cannot_bulk_delete_soft_deleted_transactions(): void
+    {
+        $transaction = Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->for($this->category)
+            ->create();
+
+        $transaction->delete();
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('transactions.bulk-destroy'), [
+                'transaction_ids' => [$transaction->id],
+            ]);
+
+        $response->assertSessionHasErrors(['transaction_ids.0']);
+    }
 }

--- a/workspace/tests/Feature/TransactionControllerTest.php
+++ b/workspace/tests/Feature/TransactionControllerTest.php
@@ -295,4 +295,47 @@ class TransactionControllerTest extends TestCase
 
         $response->assertStatus(403);
     }
+
+    public function test_can_bulk_delete_transactions(): void
+    {
+        $transactions = Transaction::factory()
+            ->for($this->user)
+            ->for($this->account)
+            ->for($this->category)
+            ->count(3)
+            ->create();
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('transactions.bulk-destroy'), [
+                'transaction_ids' => $transactions->pluck('id')->all(),
+            ]);
+
+        $response->assertRedirect(route('transactions.index'));
+        $response->assertSessionHas('success', '3 transactions deleted successfully.');
+
+        foreach ($transactions as $transaction) {
+            $this->assertSoftDeleted('transactions', [
+                'id' => $transaction->id,
+            ]);
+        }
+    }
+
+    public function test_user_cannot_bulk_delete_other_users_transactions(): void
+    {
+        $otherUser = User::factory()->create();
+        $otherAccount = Account::factory()->for($otherUser)->create();
+        $otherCategory = Category::factory()->for($otherUser)->create();
+        $transaction = Transaction::factory()
+            ->for($otherUser)
+            ->for($otherAccount, 'account')
+            ->for($otherCategory, 'category')
+            ->create();
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('transactions.bulk-destroy'), [
+                'transaction_ids' => [$transaction->id],
+            ]);
+
+        $response->assertSessionHasErrors(['transaction_ids.0']);
+    }
 }

--- a/workspace/tests/Unit/AccountingServiceTest.php
+++ b/workspace/tests/Unit/AccountingServiceTest.php
@@ -299,125 +299,139 @@ class AccountingServiceTest extends TestCase
 
     public function test_delete_transactions_returns_deleted_count_and_soft_deletes_records(): void
     {
-        $user = User::factory()->create();
-        $account = Account::factory()->for($user)->create([
-            'type' => AccountType::BANK,
-            'initial_balance' => 1000.00,
-            'created_at' => '2026-01-01 00:00:00',
-        ]);
-        $category = Category::factory()->for($user)->create();
+        $testNow = Carbon::parse('2026-01-31 12:00:00');
+        Carbon::setTestNow($testNow);
 
-        $transactionA = $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $account->id,
-            'category_id' => $category->id,
-            'amount' => 100.00,
-            'transaction_date' => '2026-01-10',
-            'type' => TransactionType::CREDIT,
-        ]);
+        try {
+            $user = User::factory()->create();
+            $account = Account::factory()->for($user)->create([
+                'type' => AccountType::BANK,
+                'initial_balance' => 1000.00,
+                'created_at' => $testNow->copy()->startOfMonth(),
+            ]);
+            $category = Category::factory()->for($user)->create();
 
-        $transactionB = $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $account->id,
-            'category_id' => $category->id,
-            'amount' => 40.00,
-            'transaction_date' => '2026-01-11',
-            'type' => TransactionType::DEBIT,
-        ]);
+            $transactionA = $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $account->id,
+                'category_id' => $category->id,
+                'amount' => 100.00,
+                'transaction_date' => $testNow->copy()->startOfMonth()->addDays(9)->format('Y-m-d'),
+                'type' => TransactionType::CREDIT,
+            ]);
 
-        $deletedCount = $this->service->deleteTransactions([$transactionA, $transactionB]);
+            $transactionB = $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $account->id,
+                'category_id' => $category->id,
+                'amount' => 40.00,
+                'transaction_date' => $testNow->copy()->startOfMonth()->addDays(10)->format('Y-m-d'),
+                'type' => TransactionType::DEBIT,
+            ]);
 
-        $this->assertSame(2, $deletedCount);
-        $this->assertSoftDeleted('transactions', ['id' => $transactionA->id]);
-        $this->assertSoftDeleted('transactions', ['id' => $transactionB->id]);
-        $this->assertEquals(
-            1000.00,
-            $this->service->calculateBalance($account->fresh(), Carbon::parse('2026-01-31'))
-        );
+            $deletedCount = $this->service->deleteTransactions([$transactionA, $transactionB]);
+
+            $this->assertSame(2, $deletedCount);
+            $this->assertSoftDeleted('transactions', ['id' => $transactionA->id]);
+            $this->assertSoftDeleted('transactions', ['id' => $transactionB->id]);
+            $this->assertEquals(
+                1000.00,
+                $this->service->calculateBalance($account->fresh(), $testNow->copy()->endOfDay())
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     public function test_delete_transactions_recalculates_snapshots_for_multiple_accounts_and_months(): void
     {
-        $user = User::factory()->create();
-        $category = Category::factory()->for($user)->create();
+        $testNow = Carbon::parse('2026-03-31 12:00:00');
+        Carbon::setTestNow($testNow);
 
-        $accountA = Account::factory()->for($user)->create([
-            'type' => AccountType::BANK,
-            'initial_balance' => 1000.00,
-            'created_at' => '2026-01-01 00:00:00',
-        ]);
+        try {
+            $user = User::factory()->create();
+            $category = Category::factory()->for($user)->create();
 
-        $accountB = Account::factory()->for($user)->create([
-            'type' => AccountType::BANK,
-            'initial_balance' => 500.00,
-            'created_at' => '2026-01-01 00:00:00',
-        ]);
+            $accountA = Account::factory()->for($user)->create([
+                'type' => AccountType::BANK,
+                'initial_balance' => 1000.00,
+                'created_at' => '2026-01-01',
+            ]);
 
-        $accountAJanCredit = $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $accountA->id,
-            'category_id' => $category->id,
-            'amount' => 100.00,
-            'transaction_date' => '2026-01-15',
-            'type' => TransactionType::CREDIT,
-        ]);
+            $accountB = Account::factory()->for($user)->create([
+                'type' => AccountType::BANK,
+                'initial_balance' => 500.00,
+                'created_at' => '2026-01-01',
+            ]);
 
-        $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $accountA->id,
-            'category_id' => $category->id,
-            'amount' => 50.00,
-            'transaction_date' => '2026-02-15',
-            'type' => TransactionType::DEBIT,
-        ]);
+            $accountAJanCredit = $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $accountA->id,
+                'category_id' => $category->id,
+                'amount' => 100.00,
+                'transaction_date' => '2026-01-15',
+                'type' => TransactionType::CREDIT,
+            ]);
 
-        $accountBFebCredit = $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $accountB->id,
-            'category_id' => $category->id,
-            'amount' => 200.00,
-            'transaction_date' => '2026-02-10',
-            'type' => TransactionType::CREDIT,
-        ]);
+            $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $accountA->id,
+                'category_id' => $category->id,
+                'amount' => 50.00,
+                'transaction_date' => '2026-02-15',
+                'type' => TransactionType::DEBIT,
+            ]);
 
-        $this->service->recordTransaction([
-            'user_id' => $user->id,
-            'account_id' => $accountB->id,
-            'category_id' => $category->id,
-            'amount' => 30.00,
-            'transaction_date' => '2026-03-05',
-            'type' => TransactionType::DEBIT,
-        ]);
+            $accountBFebCredit = $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $accountB->id,
+                'category_id' => $category->id,
+                'amount' => 200.00,
+                'transaction_date' => '2026-02-10',
+                'type' => TransactionType::CREDIT,
+            ]);
 
-        $deletedCount = $this->service->deleteTransactions([$accountAJanCredit, $accountBFebCredit]);
+            $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $accountB->id,
+                'category_id' => $category->id,
+                'amount' => 30.00,
+                'transaction_date' => '2026-03-05',
+                'type' => TransactionType::DEBIT,
+            ]);
 
-        $this->assertSame(2, $deletedCount);
+            $deletedCount = $this->service->deleteTransactions([$accountAJanCredit, $accountBFebCredit]);
 
-        $updatedAccountAJanuarySnapshot = AccountBalance::query()
-            ->where('account_id', $accountA->id)
-            ->where('year', 2026)
-            ->where('month', 1)
-            ->first();
+            $this->assertSame(2, $deletedCount);
 
-        $updatedAccountBFebruarySnapshot = AccountBalance::query()
-            ->where('account_id', $accountB->id)
-            ->where('year', 2026)
-            ->where('month', 2)
-            ->first();
+            $updatedAccountAJanuarySnapshot = AccountBalance::query()
+                ->where('account_id', $accountA->id)
+                ->where('year', 2026)
+                ->where('month', 1)
+                ->first();
 
-        $this->assertNotNull($updatedAccountAJanuarySnapshot);
-        $this->assertNotNull($updatedAccountBFebruarySnapshot);
-        $this->assertEquals(1000.00, (float) $updatedAccountAJanuarySnapshot->closing_balance);
-        $this->assertEquals(500.00, (float) $updatedAccountBFebruarySnapshot->closing_balance);
+            $updatedAccountBFebruarySnapshot = AccountBalance::query()
+                ->where('account_id', $accountB->id)
+                ->where('year', 2026)
+                ->where('month', 2)
+                ->first();
 
-        $this->assertEquals(
-            950.00,
-            $this->service->calculateBalance($accountA->fresh(), Carbon::parse('2026-03-31'))
-        );
-        $this->assertEquals(
-            470.00,
-            $this->service->calculateBalance($accountB->fresh(), Carbon::parse('2026-03-31'))
-        );
+            $this->assertNotNull($updatedAccountAJanuarySnapshot);
+            $this->assertNotNull($updatedAccountBFebruarySnapshot);
+            $this->assertEquals(1000.00, (float) $updatedAccountAJanuarySnapshot->closing_balance);
+            $this->assertEquals(500.00, (float) $updatedAccountBFebruarySnapshot->closing_balance);
+
+            $this->assertEquals(
+                950.00,
+                $this->service->calculateBalance($accountA->fresh(), Carbon::parse('2026-03-31'))
+            );
+            $this->assertEquals(
+                470.00,
+                $this->service->calculateBalance($accountB->fresh(), Carbon::parse('2026-03-31'))
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     public function test_validate_double_entry_passes_when_balanced(): void

--- a/workspace/tests/Unit/AccountingServiceTest.php
+++ b/workspace/tests/Unit/AccountingServiceTest.php
@@ -343,6 +343,42 @@ class AccountingServiceTest extends TestCase
         }
     }
 
+    public function test_delete_transactions_deduplicates_duplicate_transaction_instances(): void
+    {
+        $testNow = Carbon::parse('2026-01-31 12:00:00');
+        Carbon::setTestNow($testNow);
+
+        try {
+            $user = User::factory()->create();
+            $account = Account::factory()->for($user)->create([
+                'type' => AccountType::BANK,
+                'initial_balance' => 1000.00,
+                'created_at' => $testNow->copy()->startOfMonth(),
+            ]);
+            $category = Category::factory()->for($user)->create();
+
+            $transaction = $this->service->recordTransaction([
+                'user_id' => $user->id,
+                'account_id' => $account->id,
+                'category_id' => $category->id,
+                'amount' => 100.00,
+                'transaction_date' => $testNow->copy()->startOfMonth()->addDays(9)->format('Y-m-d'),
+                'type' => TransactionType::CREDIT,
+            ]);
+
+            $deletedCount = $this->service->deleteTransactions([$transaction, $transaction]);
+
+            $this->assertSame(1, $deletedCount);
+            $this->assertSoftDeleted('transactions', ['id' => $transaction->id]);
+            $this->assertEquals(
+                1000.00,
+                $this->service->calculateBalance($account->fresh(), $testNow->copy()->endOfDay())
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     public function test_delete_transactions_recalculates_snapshots_for_multiple_accounts_and_months(): void
     {
         $testNow = Carbon::parse('2026-03-31 12:00:00');

--- a/workspace/tests/Unit/AccountingServiceTest.php
+++ b/workspace/tests/Unit/AccountingServiceTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit;
 use App\Enums\AccountType;
 use App\Enums\TransactionType;
 use App\Models\Account;
+use App\Models\AccountBalance;
 use App\Models\Category;
 use App\Models\Tag;
 use App\Models\Transaction;
@@ -294,6 +295,129 @@ class AccountingServiceTest extends TestCase
         $balance = $this->service->calculateBalance($account->fresh(), Carbon::now());
         $this->assertEquals(1000.00, $balance);
         $this->assertSoftDeleted($transaction);
+    }
+
+    public function test_delete_transactions_returns_deleted_count_and_soft_deletes_records(): void
+    {
+        $user = User::factory()->create();
+        $account = Account::factory()->for($user)->create([
+            'type' => AccountType::BANK,
+            'initial_balance' => 1000.00,
+            'created_at' => '2026-01-01 00:00:00',
+        ]);
+        $category = Category::factory()->for($user)->create();
+
+        $transactionA = $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+            'amount' => 100.00,
+            'transaction_date' => '2026-01-10',
+            'type' => TransactionType::CREDIT,
+        ]);
+
+        $transactionB = $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $account->id,
+            'category_id' => $category->id,
+            'amount' => 40.00,
+            'transaction_date' => '2026-01-11',
+            'type' => TransactionType::DEBIT,
+        ]);
+
+        $deletedCount = $this->service->deleteTransactions([$transactionA, $transactionB]);
+
+        $this->assertSame(2, $deletedCount);
+        $this->assertSoftDeleted('transactions', ['id' => $transactionA->id]);
+        $this->assertSoftDeleted('transactions', ['id' => $transactionB->id]);
+        $this->assertEquals(
+            1000.00,
+            $this->service->calculateBalance($account->fresh(), Carbon::parse('2026-01-31'))
+        );
+    }
+
+    public function test_delete_transactions_recalculates_snapshots_for_multiple_accounts_and_months(): void
+    {
+        $user = User::factory()->create();
+        $category = Category::factory()->for($user)->create();
+
+        $accountA = Account::factory()->for($user)->create([
+            'type' => AccountType::BANK,
+            'initial_balance' => 1000.00,
+            'created_at' => '2026-01-01 00:00:00',
+        ]);
+
+        $accountB = Account::factory()->for($user)->create([
+            'type' => AccountType::BANK,
+            'initial_balance' => 500.00,
+            'created_at' => '2026-01-01 00:00:00',
+        ]);
+
+        $accountAJanCredit = $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $accountA->id,
+            'category_id' => $category->id,
+            'amount' => 100.00,
+            'transaction_date' => '2026-01-15',
+            'type' => TransactionType::CREDIT,
+        ]);
+
+        $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $accountA->id,
+            'category_id' => $category->id,
+            'amount' => 50.00,
+            'transaction_date' => '2026-02-15',
+            'type' => TransactionType::DEBIT,
+        ]);
+
+        $accountBFebCredit = $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $accountB->id,
+            'category_id' => $category->id,
+            'amount' => 200.00,
+            'transaction_date' => '2026-02-10',
+            'type' => TransactionType::CREDIT,
+        ]);
+
+        $this->service->recordTransaction([
+            'user_id' => $user->id,
+            'account_id' => $accountB->id,
+            'category_id' => $category->id,
+            'amount' => 30.00,
+            'transaction_date' => '2026-03-05',
+            'type' => TransactionType::DEBIT,
+        ]);
+
+        $deletedCount = $this->service->deleteTransactions([$accountAJanCredit, $accountBFebCredit]);
+
+        $this->assertSame(2, $deletedCount);
+
+        $updatedAccountAJanuarySnapshot = AccountBalance::query()
+            ->where('account_id', $accountA->id)
+            ->where('year', 2026)
+            ->where('month', 1)
+            ->first();
+
+        $updatedAccountBFebruarySnapshot = AccountBalance::query()
+            ->where('account_id', $accountB->id)
+            ->where('year', 2026)
+            ->where('month', 2)
+            ->first();
+
+        $this->assertNotNull($updatedAccountAJanuarySnapshot);
+        $this->assertNotNull($updatedAccountBFebruarySnapshot);
+        $this->assertEquals(1000.00, (float) $updatedAccountAJanuarySnapshot->closing_balance);
+        $this->assertEquals(500.00, (float) $updatedAccountBFebruarySnapshot->closing_balance);
+
+        $this->assertEquals(
+            950.00,
+            $this->service->calculateBalance($accountA->fresh(), Carbon::parse('2026-03-31'))
+        );
+        $this->assertEquals(
+            470.00,
+            $this->service->calculateBalance($accountB->fresh(), Carbon::parse('2026-03-31'))
+        );
     }
 
     public function test_validate_double_entry_passes_when_balanced(): void


### PR DESCRIPTION
Closes #51

Implements bulk transaction deletion on the Transactions list:
- adds row checkboxes and a select-all checkbox
- enables a header delete action only when rows are selected
- removes the per-row delete button
- adds server-side validation and bulk deletion handling with balance recalculation
- covers the new flow with feature and Jest tests